### PR TITLE
Add containerised multi-agent research workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,108 @@
-# Miau
-Miau WhisperX Service
+# Miau Research Orchestration
+
+Dieses Repository erweitert den ursprünglichen **Miau WhisperX Service** um ein klar strukturiertes Multi-Agenten-Rechercheteam. Der Fokus liegt auf qualitativ hochwertigen Wissensquellen (Paper > Blogposts), modernen RAG-Bausteinen und einem reproduzierbaren Container-Setup, das die komplette Pipeline ausführbar macht.
+
+## Projektüberblick
+
+Der Multi-Agenten-Workflow besteht aus fünf Rollen, die einander die Staffel übergeben:
+
+1. **Research Strategist** – schärft Zielsetzung, Constraints und den Arbeitsplan.
+2. **Data Miner** – führt priorisierte Websuchen durch, nutzt Crawl4AI für Scraping und speichert Ergebnisse in Vektor- und Graph-Indizes.
+3. **Data Analyst** – formatiert Dokumente strukturiert mit Docling, analysiert Evidenz und sucht gezielt nach aktuellen Reranker-Modellen.
+4. **Research Writer** – fasst Erkenntnisse zu einem Research-Report zusammen.
+5. **LangGraph Orchestrator** – optionaler StateGraph, der die Pipeline zustandsbasiert ausführt.
+
+Die Agenten teilen sich einen `ResearchState`, der über Pydantic validiert wird und damit eine typsichere Grundlage für LangGraph, PGVector und Neo4j schafft.
+
+## Technologie-Stack
+
+| Komponente | Zweck |
+|------------|-------|
+| **Pydantic** | Definiert Schemas für Wissensquellen, Artefakte und den geteilten Zustand |
+| **LangGraph** | Optionaler StateGraph, der das Agenten-Team orkestriert |
+| **DuckDuckGo / Tavily** | Internet-Suche (DuckDuckGo ist als Default integriert, Tavily lässt sich austauschen) |
+| **Crawl4AI** | Robustes Webscraping mit Fallback auf `requests` |
+| **Docling** | Structured Output / Summaries |
+| **PGVector** | Hybrid-RAG Speicher für Dokumente |
+| **Neo4j** | GraphRAG zur Verbindung thematischer Nachbarn |
+
+> Eine auf das Multi-Agenten-Team zugeschnittene Abhängigkeitsliste findet sich in [`Requirments_Agents.txt`](./Requirments_Agents.txt).
+
+## Verzeichnisstruktur
+
+```
+services/
+└── multi_agent/
+    ├── agents.py            # Implementierung der einzelnen Rollen
+    ├── integrations.py      # Suche, Scraping, Vektor- und Graphspeicher
+    ├── schemas.py           # Pydantic-Modelle & Priorisierungen
+    ├── team.py              # Orchestrator + optionale LangGraph-Pipeline
+    ├── cli.py               # Kommandozeilen-Einstiegspunkt
+    ├── __main__.py          # ermöglicht `python -m services.multi_agent`
+    └── README.md (optional, siehe unten)
+```
+
+## Priorisierte Wissensquellen
+
+Die Standardkonfiguration (`DEFAULT_PRIORITIZED_SOURCES`) gewichtet hochwertige Quellen höher:
+
+- arXiv & ACL Anthology (Priority 5)
+- OpenReview (Priority 4)
+- Hugging Face Model Hub (Priority 3)
+- GitHub (Priority 2)
+- Spezialisierte Blogs (Priority 1)
+
+Diese Gewichtung fließt sowohl in die Suchanfragen als auch in die Score-Normalisierung ein.
+
+## Containerisierung
+
+Für die Multi-Agenten-Pipeline wurde ein eigenständiger Container-Stack ergänzt:
+
+- [`services/multi_agent/Dockerfile`](services/multi_agent/Dockerfile) baut ein leichtgewichtiges Image auf Basis von `python:3.11-slim` und installiert `Requirments_Agents.txt`.
+- [`services/multi_agent/docker-compose.yml`](services/multi_agent/docker-compose.yml) startet den Container und erlaubt die Steuerung über Umgebungsvariablen.
+
+### Schnelleinstieg
+
+```bash
+# Repository klonen
+cd services/multi_agent
+
+# Container bauen und starten
+docker compose up --build
+```
+
+Wichtige Umgebungsvariablen (via `.env` oder `docker compose`):
+
+| Variable | Beschreibung |
+|----------|--------------|
+| `MULTI_AGENT_GOAL` | Ziel der Recherche (Standard: „Identify state-of-the-art reranker models…“) |
+| `MULTI_AGENT_CONSTRAINTS` | Kommagetrennte Liste von Constraints |
+
+Die Standardausgabe des Containers ist ein strukturierter Research-Report inklusive Protokoll.
+
+## Lokale Nutzung
+
+Die CLI kann auch lokal ohne Docker verwendet werden:
+
+```bash
+python -m services.multi_agent "Find the best reranker models for hybrid RAG"
+
+# Mehrere Constraints
+python -m services.multi_agent "Trend-Analyse zu Rerankern" \
+  --constraint "Fokus auf ACL 2023-2024" \
+  --constraint "Evaluierung anhand von BEIR Benchmarks"
+```
+
+Für Integrations-Tests ohne Netzwerkanfragen:
+
+```bash
+python -m services.multi_agent --dry-run
+```
+
+## Weiterführende Hinweise
+
+- Die LangGraph-Integration ist optional und wird nur aktiviert, wenn das Paket installiert ist.
+- PGVector- und Neo4j-Verbindungen können durch Ersetzen der In-Memory-Implementierungen (`InMemoryVectorStore`, `InMemoryGraphRAG`) hergestellt werden.
+- Der Data Analyst sucht standardmäßig nach Reranker-Modellen mit Fokus auf peer-reviewte Veröffentlichungen.
+
+Viel Erfolg beim Erkunden des Multi-Agenten-Stacks!

--- a/Requirments_Agents.txt
+++ b/Requirments_Agents.txt
@@ -1,0 +1,13 @@
+# Dependencies for the multi-agent research workflow
+# Packages marked as optional unlock the full integration stack described in the README.
+
+pydantic>=2.5,<3.0
+requests>=2.31,<3.0
+langgraph>=0.1.0
+crawl4ai>=0.1.36  # optional: enables production-grade web crawling
+python-dotenv>=1.0.0  # optional: convenient environment variable loading for CLI usage
+neo4j>=5.20.0  # optional: connect to a managed or self-hosted Neo4j instance
+pgvector>=0.2.5  # optional: PGVector-backed hybrid retrieval
+psycopg[binary]>=3.2.1  # optional: PostgreSQL driver for PGVector usage
+docling>=0.4.2  # optional: structured document summarisation
+openai>=1.3.0  # optional: for reranker experimentation via API providers

--- a/services/multi_agent/Dockerfile
+++ b/services/multi_agent/Dockerfile
@@ -1,0 +1,16 @@
+# Lightweight container for the multi-agent research workflow
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY Requirments_Agents.txt ./Requirments_Agents.txt
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r Requirments_Agents.txt
+
+COPY services /app/services
+
+ENTRYPOINT ["python", "-m", "services.multi_agent"]
+CMD []

--- a/services/multi_agent/README.md
+++ b/services/multi_agent/README.md
@@ -1,0 +1,24 @@
+# Multi-Agent Research Team
+
+Dieses Verzeichnis enthält den modularen Multi-Agenten-Stack, der in der Projekt-README beschrieben wird. Kernfeatures:
+
+- **Priorisierte Wissensquellen** mit expliziten Gewichten (Paper > Blogs).
+- **Integrationen** für DuckDuckGo/Tavily, Crawl4AI, Docling, PGVector & Neo4j.
+- **LangGraph**-kompatible Orchestrierung via `MultiAgentSearchTeam.langgraph_app`.
+- **CLI** (`python -m services.multi_agent`), die Ziele und Constraints aus Argumenten oder Umgebungsvariablen liest.
+
+## Entwicklung
+
+```bash
+python -m compileall services/multi_agent
+python -m services.multi_agent --dry-run
+```
+
+## Container
+
+```bash
+cd services/multi_agent
+docker compose up --build
+```
+
+Die Container-Variante nutzt [`Requirments_Agents.txt`](../../Requirments_Agents.txt) für die Abhängigkeiten.

--- a/services/multi_agent/__init__.py
+++ b/services/multi_agent/__init__.py
@@ -1,0 +1,53 @@
+"""Multi-agent research orchestration components."""
+
+from .agents import DataAnalyst, DataMiner, ResearchStrategist, ResearchWriter
+from .integrations import (
+    Crawl4AIScraper,
+    DoclinFormatter,
+    DuckDuckGoSearchClient,
+    InMemoryGraphRAG,
+    InMemoryVectorStore,
+    SearchClient,
+)
+from .cli import build_parser, run_cli
+from .schemas import (
+    DEFAULT_PRIORITIZED_SOURCES,
+    GatheredEvidence,
+    KnowledgeSource,
+    PrioritizedKnowledgeSources,
+    ResearchArtifact,
+    ResearchPlan,
+    ResearchPlanStep,
+    ResearchState,
+    RerankerModelCandidate,
+    ScrapedDocument,
+    SearchResult,
+)
+from .team import MultiAgentSearchTeam
+
+__all__ = [
+    "DataAnalyst",
+    "DataMiner",
+    "ResearchStrategist",
+    "ResearchWriter",
+    "Crawl4AIScraper",
+    "DoclinFormatter",
+    "DuckDuckGoSearchClient",
+    "InMemoryGraphRAG",
+    "InMemoryVectorStore",
+    "SearchClient",
+    "DEFAULT_PRIORITIZED_SOURCES",
+    "GatheredEvidence",
+    "KnowledgeSource",
+    "PrioritizedKnowledgeSources",
+    "ResearchArtifact",
+    "ResearchPlan",
+    "ResearchPlanStep",
+    "ResearchState",
+    "RerankerModelCandidate",
+    "ScrapedDocument",
+    "SearchResult",
+    "MultiAgentSearchTeam",
+    "run_cli",
+    "build_parser",
+]

--- a/services/multi_agent/__main__.py
+++ b/services/multi_agent/__main__.py
@@ -1,0 +1,15 @@
+"""Module entrypoint so the workflow can run via ``python -m services.multi_agent``."""
+
+from __future__ import annotations
+
+from .cli import run_cli
+
+
+def main() -> int:
+    """Execute the command line interface."""
+
+    return run_cli()
+
+
+if __name__ == "__main__":  # pragma: no cover - enables direct execution
+    raise SystemExit(main())

--- a/services/multi_agent/agents.py
+++ b/services/multi_agent/agents.py
@@ -1,0 +1,370 @@
+"""Agent implementations for the research workflow."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from .integrations import (
+    Crawl4AIScraper,
+    DoclinFormatter,
+    DuckDuckGoSearchClient,
+    InMemoryGraphRAG,
+    InMemoryVectorStore,
+    SearchClient,
+)
+from .schemas import (
+    GatheredEvidence,
+    KnowledgeSource,
+    PrioritizedKnowledgeSources,
+    ResearchArtifact,
+    ResearchPlan,
+    ResearchPlanStep,
+    ResearchState,
+    RerankerModelCandidate,
+    ScrapedDocument,
+    SearchResult,
+)
+
+
+class ResearchStrategist:
+    """Agent responsible for defining the goal and building the plan."""
+
+    def __init__(self, prioritized_sources: PrioritizedKnowledgeSources) -> None:
+        self.prioritized_sources = prioritized_sources
+
+    def define_problem(
+        self, goal: str, constraints: Optional[Sequence[str]] = None
+    ) -> ResearchState:
+        state = ResearchState(
+            goal=goal,
+            constraints=list(constraints or []),
+            prioritized_sources=self.prioritized_sources,
+        )
+        state.log("Research Strategist defined the objective and constraints.")
+        return state
+
+    def build_plan(self, state: ResearchState) -> ResearchPlan:
+        steps = [
+            ResearchPlanStep(
+                order=1,
+                agent_role="Research Strategist",
+                description="Spezifiziere Zielsetzung, Erfolgsmetriken und Kontextinformationen.",
+                expected_output="Projektbriefing mit klarer Problemdefinition",
+                success_criteria=[
+                    "Explizite Zielbeschreibung",
+                    "Liste harter Constraints",
+                ],
+            ),
+            ResearchPlanStep(
+                order=2,
+                agent_role="Data Miner",
+                description=(
+                    "Suche fokussiert nach hochwertigen Quellen (Paper vor Blogs) unter Nutzung"
+                    " der priorisierten Wissensquellen."
+                ),
+                expected_output="Korpus relevanter Dokumente mit Metadaten",
+                success_criteria=[
+                    "Bevorzugung von peer-reviewten Publikationen",
+                    "Abdeckung aktueller Entwicklungen",
+                ],
+            ),
+            ResearchPlanStep(
+                order=3,
+                agent_role="Data Analyst",
+                description=(
+                    "Analysiere und strukturiere die Dokumente. Suche aktiv nach aktuellen "
+                    "Reranker-Modellen und bewerte diese."
+                ),
+                expected_output="Strukturierte Insights, extrahierte Modelle und Bewertungsmatrix",
+                success_criteria=[
+                    "Identifizierte Reranker-Modelle",
+                    "Bewertete Evidenzqualität",
+                ],
+            ),
+            ResearchPlanStep(
+                order=4,
+                agent_role="Research Writer",
+                description="Verdichte Ergebnisse zu einem Research-Report mit Handlungsempfehlungen.",
+                expected_output="Veröffentlichungsreifer Bericht",
+                success_criteria=[
+                    "Klare Zusammenfassung",
+                    "Quellennachweise",
+                ],
+            ),
+        ]
+        rationale = (
+            "Die Planung stellt sicher, dass hochwertigere Wissensquellen höher gewichtet werden. "
+            "Durch den Fokus auf peer-reviewte Publikationen und modellbezogene Recherchen entsteht "
+            "eine belastbare Entscheidungsgrundlage."
+        )
+        plan = ResearchPlan(goal=state.goal, rationale=rationale, steps=steps)
+        state.plan = plan
+        state.log("Research Strategist entwickelte einen vierstufigen Plan.")
+        return plan
+
+
+class DataMiner:
+    """Agent gathering evidence using the configured search and scraping stack."""
+
+    def __init__(
+        self,
+        *,
+        prioritized_sources: PrioritizedKnowledgeSources,
+        search_client: Optional[SearchClient] = None,
+        scraper: Optional[Crawl4AIScraper] = None,
+        vector_store: Optional[InMemoryVectorStore] = None,
+        graph_store: Optional[InMemoryGraphRAG] = None,
+        max_results_per_source: int = 3,
+    ) -> None:
+        self.prioritized_sources = prioritized_sources
+        self.search_client = search_client or DuckDuckGoSearchClient()
+        self.scraper = scraper or Crawl4AIScraper()
+        self.vector_store = vector_store or InMemoryVectorStore()
+        self.graph_store = graph_store or InMemoryGraphRAG()
+        self.max_results_per_source = max_results_per_source
+
+    def gather(self, state: ResearchState) -> GatheredEvidence:
+        search_results: List[SearchResult] = []
+        documents: List[ScrapedDocument] = []
+
+        for source in self.prioritized_sources.sorted_sources():
+            for query in self._queries_for_source(state, source):
+                for result in self.search_client.search(
+                    query, max_results=self.max_results_per_source
+                ):
+                    weighted_result = self._apply_source_weight(result, source)
+                    search_results.append(weighted_result)
+                    document = self._scrape_result(weighted_result, source)
+                    if document is None:
+                        continue
+                    documents.append(document)
+                    self.vector_store.upsert(document)
+                    self.graph_store.upsert_document(document)
+            state.log(
+                f"Data Miner suchte nach '{state.goal}' mit Schwerpunkt auf {source.name}."
+            )
+
+        state.knowledge_base.extend(documents)
+        state.log(
+            "Data Miner sammelte %d Dokumente und speicherte sie im Vector- und Graph-Index."
+            % len(documents)
+        )
+        return GatheredEvidence(documents=documents, search_results=search_results)
+
+    def _queries_for_source(
+        self, state: ResearchState, source: KnowledgeSource
+    ) -> Iterable[str]:
+        keywords = list(state.context.get("keywords", []))
+        base_queries = [state.goal] + keywords
+        return [f"{query} {source.name}" for query in base_queries]
+
+    def _apply_source_weight(
+        self, result: SearchResult, source: KnowledgeSource
+    ) -> SearchResult:
+        weighted_score = (result.score or 1.0) * source.priority * source.weight
+        return result.model_copy(update={"score": weighted_score, "source": source.name})
+
+    def _scrape_result(
+        self, result: SearchResult, source: KnowledgeSource
+    ) -> Optional[ScrapedDocument]:
+        page_text = self.scraper.scrape(str(result.url))
+        if not page_text:
+            return None
+        return ScrapedDocument(
+            url=result.url,
+            source=source.name,
+            title=result.title,
+            content=page_text,
+            metadata={
+                "source_kind": source.kind,
+                "priority": source.priority,
+                "weight": source.weight,
+            },
+        )
+
+
+class DataAnalyst:
+    """Agent that synthesises gathered data and searches for reranker models."""
+
+    def __init__(
+        self,
+        *,
+        prioritized_sources: PrioritizedKnowledgeSources,
+        doc_formatter: Optional[DoclinFormatter] = None,
+        vector_store: Optional[InMemoryVectorStore] = None,
+        graph_store: Optional[InMemoryGraphRAG] = None,
+        search_client: Optional[SearchClient] = None,
+        reranker_limit: int = 5,
+    ) -> None:
+        self.prioritized_sources = prioritized_sources
+        self.doc_formatter = doc_formatter or DoclinFormatter()
+        self.vector_store = vector_store or InMemoryVectorStore()
+        self.graph_store = graph_store or InMemoryGraphRAG()
+        self.search_client = search_client or DuckDuckGoSearchClient()
+        self.reranker_limit = reranker_limit
+
+    def refine(
+        self, state: ResearchState, evidence: GatheredEvidence
+    ) -> ResearchArtifact:
+        relevant_documents = self._select_relevant_documents(state, evidence)
+        structured = self.doc_formatter.to_structured_summary(relevant_documents)
+        rerankers = self._search_reranker_models(state)
+        state.reranker_models = rerankers
+
+        insights = self._extract_key_points(structured)
+        content_lines = ["Synthese der wichtigsten Erkenntnisse:", ""]
+        content_lines.extend(f"- {insight}" for insight in insights)
+        if rerankers:
+            content_lines.append("")
+            content_lines.append("Identifizierte Reranker-Modelle:")
+            for candidate in rerankers:
+                detail = f"- {candidate.name} (Quelle: {candidate.source})"
+                if candidate.url:
+                    detail += f" – {candidate.url}"
+                content_lines.append(detail)
+
+        metadata: Dict[str, Any] = {
+            "structured_summary": structured,
+            "reranker_candidates": [candidate.model_dump() for candidate in rerankers],
+        }
+        graph_context = self._graph_context(relevant_documents)
+        if graph_context:
+            metadata["graph_neighbours"] = graph_context
+
+        artifact = ResearchArtifact(
+            kind="analysis",
+            title="Strukturierte Analyse der Recherche",
+            content="\n".join(content_lines),
+            source_links=[document.url for document in relevant_documents],
+            metadata=metadata,
+        )
+        state.artifacts.append(artifact)
+        state.log(
+            "Data Analyst verdichtete die Evidenz und identifizierte Reranker-Modelle."
+        )
+        return artifact
+
+    def _select_relevant_documents(
+        self, state: ResearchState, evidence: GatheredEvidence
+    ) -> List[ScrapedDocument]:
+        vector_hits = self.vector_store.similarity_search(state.goal, top_k=6)
+        if not vector_hits:
+            return evidence.documents
+        seen = {str(doc.url) for doc in vector_hits}
+        for document in evidence.documents:
+            if str(document.url) not in seen:
+                vector_hits.append(document)
+                seen.add(str(document.url))
+        return vector_hits
+
+    def _extract_key_points(self, structured_summary: Dict[str, Any]) -> List[str]:
+        insights: List[str] = []
+        for item in structured_summary.get("summary", []):
+            points = item.get("key_points") or []
+            if not points:
+                continue
+            insights.append(f"{item['title']}: {points[0]}")
+        return insights
+
+    def _graph_context(self, documents: Sequence[ScrapedDocument]) -> Dict[str, List[str]]:
+        context: Dict[str, List[str]] = {}
+        for doc in documents:
+            neighbours = self.graph_store.neighbours(str(doc.url))
+            if neighbours:
+                context[str(doc.url)] = neighbours
+        return context
+
+    def _search_reranker_models(self, state: ResearchState) -> List[RerankerModelCandidate]:
+        queries = [
+            f"{state.goal} reranker model",
+            "state-of-the-art reranker model 2024",
+            "information retrieval reranker benchmark",
+        ]
+        candidates: Dict[str, RerankerModelCandidate] = {}
+        for source in self.prioritized_sources.sorted_sources():
+            if source.kind not in {"paper", "model", "benchmark"}:
+                continue
+            for query in queries:
+                weighted_query = f"{query} {source.name}"
+                results = self.search_client.search(weighted_query, max_results=2)
+                for result in results:
+                    score = (result.score or 1.0) * source.priority * source.weight
+                    candidate = RerankerModelCandidate(
+                        name=result.title,
+                        source=source.name,
+                        url=result.url,
+                        score=score,
+                        notes="Identifiziert über priorisierte Reranker-Recherche",
+                    )
+                    key = str(result.url)
+                    if key not in candidates or candidates[key].score < score:
+                        candidates[key] = candidate
+        ordered = sorted(
+            candidates.values(), key=lambda candidate: candidate.score, reverse=True
+        )
+        return ordered[: self.reranker_limit]
+
+
+class ResearchWriter:
+    """Agent assembling the final research report."""
+
+    def __init__(self, template_name: str = "default") -> None:
+        self.template_name = template_name
+
+    def generate(
+        self, state: ResearchState, analysis: ResearchArtifact
+    ) -> ResearchArtifact:
+        lines = [
+            f"Forschungsbericht: {state.goal}",
+            "= " + "=" * (len(state.goal) + 17),
+            "",
+            "Zusammenfassung:",
+            analysis.content,
+            "",
+            "Constraints:",
+        ]
+        lines.extend(f"- {constraint}" for constraint in state.constraints or ["Keine"])
+        if state.plan:
+            lines.append("")
+            lines.append("Forschungsplan:")
+            for step in state.plan.steps:
+                lines.append(
+                    f"- Schritt {step.order}: {step.agent_role} – {step.description}"
+                )
+        if state.reranker_models:
+            lines.append("")
+            lines.append("Empfohlene Reranker-Modelle:")
+            for candidate in state.reranker_models:
+                lines.append(
+                    f"- {candidate.name} (Quelle: {candidate.source}, Score: {candidate.score:.2f})"
+                )
+        lines.append("")
+        lines.append("Priorisierte Wissensquellen:")
+        for source in state.prioritized_sources.sorted_sources():
+            lines.append(
+                f"- {source.name} ({source.kind}, Priorität {source.priority})"
+            )
+
+        artifact = ResearchArtifact(
+            kind="report",
+            title=f"Research Report – {state.goal}",
+            content="\n".join(lines),
+            source_links=[link for link in analysis.source_links],
+            metadata={
+                "state_log": list(state.state_log),
+                "reranker_models": [candidate.model_dump() for candidate in state.reranker_models],
+                "prioritized_sources": state.prioritized_sources.as_display(),
+                "template": self.template_name,
+            },
+        )
+        state.artifacts.append(artifact)
+        state.log("Research Writer generierte den finalen Bericht.")
+        return artifact
+
+
+__all__ = [
+    "ResearchStrategist",
+    "DataMiner",
+    "DataAnalyst",
+    "ResearchWriter",
+]

--- a/services/multi_agent/cli.py
+++ b/services/multi_agent/cli.py
@@ -1,0 +1,98 @@
+"""Command line interface for running the multi-agent research workflow."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Iterable, Sequence
+
+from .team import MultiAgentSearchTeam
+
+DEFAULT_GOAL = "Identify state-of-the-art reranker models for information retrieval"
+DEFAULT_CONSTRAINTS: Sequence[str] = (
+    "Prioritise peer-reviewed research papers",
+    "Prefer resources published after 2022",
+)
+
+
+def _env_constraints(value: str | None) -> Sequence[str]:
+    """Parse environment-supplied constraints (comma separated)."""
+
+    if not value:
+        return ()
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the ``argparse`` parser used by the CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute the multi-agent research workflow that orchestrates the "
+            "Research Strategist, Data Miner, Data Analyst and Research Writer."
+        )
+    )
+    parser.add_argument(
+        "goal",
+        nargs="?",
+        default=os.getenv("MULTI_AGENT_GOAL", DEFAULT_GOAL),
+        help="Research goal to pursue. Defaults to the MULTI_AGENT_GOAL environment variable.",
+    )
+    parser.add_argument(
+        "--constraint",
+        "-c",
+        action="append",
+        dest="constraints",
+        default=None,
+        help="Hard constraint for the research task. Repeat the flag for multiple constraints.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Initialise all agents without executing the workflow. Useful for integration tests "
+            "that only need to validate wiring."
+        ),
+    )
+    return parser
+
+
+def run_cli(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI, returning the resulting exit code."""
+
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    env_constraints = _env_constraints(os.getenv("MULTI_AGENT_CONSTRAINTS"))
+    constraints: Iterable[str]
+    if args.constraints:
+        constraints = args.constraints
+    elif env_constraints:
+        constraints = env_constraints
+    else:
+        constraints = DEFAULT_CONSTRAINTS
+
+    team = MultiAgentSearchTeam()
+    if args.dry_run:
+        # Trigger lazy initialisation such as LangGraph compilation without running the agents.
+        if team.langgraph_app is not None:
+            team.langgraph_app
+        return 0
+
+    report = team.run(args.goal, constraints=tuple(constraints))
+    print("\n" + "=" * 80)
+    print(report.title)
+    print("=" * 80)
+    print(report.content)
+    if team.state is not None:
+        print("\nProtokoll:")
+        for entry in team.state.state_log:
+            print(f"- {entry}")
+    return 0
+
+
+__all__ = ["run_cli", "build_parser"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    raise SystemExit(run_cli())

--- a/services/multi_agent/docker-compose.yml
+++ b/services/multi_agent/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  multi-agent-search:
+    build:
+      context: ../..
+      dockerfile: services/multi_agent/Dockerfile
+    environment:
+      MULTI_AGENT_GOAL: "Identify state-of-the-art reranker models for information retrieval"
+      MULTI_AGENT_CONSTRAINTS: "Prefer peer-reviewed sources,Highlight results from 2022 onwards"
+    tty: true
+    stdin_open: true
+    command: []

--- a/services/multi_agent/integrations.py
+++ b/services/multi_agent/integrations.py
@@ -1,0 +1,239 @@
+"""Integration helpers for external research tooling.
+
+Each helper stays deliberately lightweight so the module is importable even when
+optional dependencies (Crawl4AI, Doclin, etc.) are unavailable. When a
+dependency is missing the code falls back to simple Python-only behaviour which
+keeps the overall developer experience smooth while still documenting where real
+integrations would plug in.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
+from urllib.parse import parse_qs, unquote, urlparse
+
+import requests
+
+from .schemas import ScrapedDocument, SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+class SearchClient(Protocol):
+    """Protocol used for internet search clients (DuckDuckGo, Tavily, etc.)."""
+
+    def search(self, query: str, *, max_results: int = 5) -> List[SearchResult]:
+        """Return a list of ``SearchResult`` objects for the given query."""
+
+
+class DuckDuckGoSearchClient:
+    """Minimal DuckDuckGo search implementation used as the default search client."""
+
+    def __init__(
+        self,
+        *,
+        region: str = "wt-wt",
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.region = region
+        self.session = session or requests.Session()
+
+    def search(self, query: str, *, max_results: int = 5) -> List[SearchResult]:
+        params = {"q": query, "kl": self.region, "kp": -2}
+        headers = {
+            "User-Agent": "Mozilla/5.0 (MultiAgentSearchTeam; compatible)",
+            "Accept-Language": "en-US,en;q=0.5",
+        }
+        try:
+            response = self.session.get(
+                "https://duckduckgo.com/html/",
+                params=params,
+                headers=headers,
+                timeout=10,
+            )
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network may be blocked in CI
+            logger.warning("DuckDuckGo search failed: %s", exc)
+            return []
+
+        pattern = re.compile(
+            r'<a rel="nofollow" class="result__a" href="(?P<href>[^\"]+)">(?P<title>.*?)</a>',
+            re.S,
+        )
+        matches = pattern.finditer(response.text)
+        results: List[SearchResult] = []
+        for match in matches:
+            href = match.group("href")
+            parsed = urlparse(href)
+            url = href
+            if parsed.netloc == "duckduckgo.com":
+                query_dict = parse_qs(parsed.query)
+                uddg = query_dict.get("uddg")
+                if uddg:
+                    url = unquote(uddg[0])
+            title = re.sub(r"<.*?>", "", match.group("title")).strip()
+            snippet = None
+            results.append(
+                SearchResult(
+                    title=title or query,
+                    url=url,
+                    snippet=snippet,
+                    source="duckduckgo",
+                    score=float(len(results) + 1),
+                )
+            )
+            if len(results) >= max_results:
+                break
+        return results
+
+
+class Crawl4AIScraper:
+    """Lightweight wrapper that prefers Crawl4AI and falls back to ``requests``."""
+
+    def __init__(self) -> None:
+        try:  # pragma: no cover - optional dependency
+            from crawl4ai import WebCrawler  # type: ignore
+
+            self._crawler_cls = WebCrawler
+        except Exception:  # pragma: no cover - executed when dependency missing
+            self._crawler_cls = None
+        self._session = requests.Session()
+
+    def scrape(self, url: str) -> Optional[str]:
+        if self._crawler_cls is not None:  # pragma: no cover - requires crawl4ai
+            crawler = self._crawler_cls()
+            try:
+                page = crawler.run(url)
+                if page and hasattr(page, "content"):
+                    return str(page.content)
+            except Exception as exc:  # pragma: no cover - depends on external site
+                logger.warning("Crawl4AI scraping failed: %s", exc)
+
+        try:
+            response = self._session.get(
+                url, timeout=10, headers={"User-Agent": "Mozilla/5.0"}
+            )
+            response.raise_for_status()
+            return response.text
+        except Exception as exc:  # pragma: no cover - network may be blocked
+            logger.warning("Fallback scraping failed: %s", exc)
+            return None
+
+
+class DoclinFormatter:
+    """Produces structured summaries, integrating with Doclin when available."""
+
+    def __init__(self) -> None:
+        try:  # pragma: no cover - optional dependency
+            from docling import Document  # type: ignore
+
+            self._doc_class = Document
+        except Exception:  # pragma: no cover - executed when dependency missing
+            self._doc_class = None
+
+    def to_structured_summary(
+        self, documents: Sequence[ScrapedDocument]
+    ) -> Dict[str, Any]:
+        """Return a structured summary of the supplied documents."""
+
+        summary: List[Dict[str, Any]] = []
+        for document in documents:
+            key_points = []
+            for line in document.content.splitlines():
+                line = line.strip()
+                if len(line) > 12:
+                    key_points.append(line)
+                if len(key_points) >= 3:
+                    break
+            summary.append(
+                {
+                    "title": document.title or document.source,
+                    "url": str(document.url),
+                    "key_points": key_points,
+                    "metadata": document.metadata,
+                }
+            )
+        if self._doc_class is not None:  # pragma: no cover - requires docling
+            try:
+                structured = self._doc_class(summary=json.dumps(summary))
+                return {"doclin_document": structured, "summary": summary}
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Doclin conversion failed: %s", exc)
+        return {"summary": summary}
+
+
+class InMemoryVectorStore:
+    """Simple vector store emulating PGVector behaviour for local execution."""
+
+    def __init__(self) -> None:
+        self._documents: Dict[str, Tuple[Dict[str, int], ScrapedDocument]] = {}
+
+    @staticmethod
+    def _tokenise(text: str) -> Dict[str, int]:
+        tokens = re.findall(r"\b\w+\b", text.lower())
+        counts: Dict[str, int] = {}
+        for token in tokens:
+            counts[token] = counts.get(token, 0) + 1
+        return counts
+
+    @staticmethod
+    def _cosine_similarity(vec_a: Dict[str, int], vec_b: Dict[str, int]) -> float:
+        shared = set(vec_a) & set(vec_b)
+        numerator = sum(vec_a[token] * vec_b[token] for token in shared)
+        denom_a = math.sqrt(sum(value * value for value in vec_a.values()))
+        denom_b = math.sqrt(sum(value * value for value in vec_b.values()))
+        if denom_a == 0 or denom_b == 0:
+            return 0.0
+        return numerator / (denom_a * denom_b)
+
+    def upsert(self, document: ScrapedDocument) -> None:
+        vector = self._tokenise(document.content)
+        self._documents[str(document.url)] = (vector, document)
+
+    def similarity_search(self, query: str, *, top_k: int = 5) -> List[ScrapedDocument]:
+        query_vec = self._tokenise(query)
+        scored: List[Tuple[float, ScrapedDocument]] = []
+        for vector, document in self._documents.values():
+            score = self._cosine_similarity(vector, query_vec)
+            scored.append((score, document))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [doc for score, doc in scored[:top_k] if score > 0]
+
+
+class InMemoryGraphRAG:
+    """Lightweight Neo4j-inspired graph store for entity linking."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Dict[str, Any]] = {}
+        self._edges: List[Tuple[str, str, str]] = []
+
+    def upsert_document(self, document: ScrapedDocument) -> None:
+        node_id = str(document.url)
+        self._nodes[node_id] = {
+            "title": document.title,
+            "source": document.source,
+            "metadata": document.metadata,
+        }
+        # Connect by source to emphasise prioritised knowledge providers
+        for existing_id, meta in list(self._nodes.items()):
+            if existing_id == node_id:
+                continue
+            if meta.get("source") == document.source:
+                self._edges.append((node_id, existing_id, "same_source"))
+
+    def neighbours(self, node_id: str) -> List[str]:
+        return [edge[1] for edge in self._edges if edge[0] == node_id]
+
+
+__all__ = [
+    "SearchClient",
+    "DuckDuckGoSearchClient",
+    "Crawl4AIScraper",
+    "DoclinFormatter",
+    "InMemoryVectorStore",
+    "InMemoryGraphRAG",
+]

--- a/services/multi_agent/schemas.py
+++ b/services/multi_agent/schemas.py
@@ -1,0 +1,240 @@
+"""Data schemas used by the research multi-agent workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, HttpUrl
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeSource(BaseModel):
+    """Represents a single knowledge source with an explicit priority weight."""
+
+    name: str = Field(..., description="Human readable name of the source")
+    kind: str = Field(
+        ..., description="Type of source (paper, benchmark, blog, dataset, etc.)"
+    )
+    priority: int = Field(
+        1,
+        ge=1,
+        description="Higher priority numbers indicate more trusted or relevant sources.",
+    )
+    weight: float = Field(
+        1.0,
+        ge=0.0,
+        description="Continuous weight used when scoring documents coming from the source.",
+    )
+    url: Optional[HttpUrl] = Field(
+        None, description="Canonical URL of the knowledge base, if applicable."
+    )
+    tags: List[str] = Field(default_factory=list, description="Additional metadata tags.")
+
+    model_config = {"protected_namespaces": ()}
+
+
+class PrioritizedKnowledgeSources(BaseModel):
+    """Holds a list of knowledge sources sorted by their weight/priority."""
+
+    sources: List[KnowledgeSource] = Field(default_factory=list)
+
+    model_config = {"protected_namespaces": ()}
+
+    def sorted_sources(self) -> List[KnowledgeSource]:
+        """Return sources sorted by ``priority`` and ``weight`` descending."""
+
+        return sorted(
+            self.sources,
+            key=lambda item: (item.priority, item.weight, item.name.lower()),
+            reverse=True,
+        )
+
+    def top_sources(self, limit: Optional[int] = None) -> List[KnowledgeSource]:
+        """Return the top ``limit`` sources with the highest priority."""
+
+        ordered = self.sorted_sources()
+        if limit is None:
+            return ordered
+        return ordered[:limit]
+
+    def as_display(self) -> List[Dict[str, Any]]:
+        """Return a serialisable representation useful for reporting."""
+
+        return [
+            {"name": src.name, "kind": src.kind, "priority": src.priority}
+            for src in self.sorted_sources()
+        ]
+
+
+DEFAULT_PRIORITIZED_SOURCES = PrioritizedKnowledgeSources(
+    sources=[
+        KnowledgeSource(
+            name="arXiv",
+            kind="paper",
+            priority=5,
+            weight=1.0,
+            url="https://arxiv.org",
+            tags=["peer-reviewed", "ml"],
+        ),
+        KnowledgeSource(
+            name="ACL Anthology",
+            kind="paper",
+            priority=5,
+            weight=0.95,
+            url="https://aclanthology.org",
+            tags=["nlp", "peer-reviewed"],
+        ),
+        KnowledgeSource(
+            name="OpenReview",
+            kind="paper",
+            priority=4,
+            weight=0.9,
+            url="https://openreview.net",
+            tags=["peer-reviewed", "conference"],
+        ),
+        KnowledgeSource(
+            name="Hugging Face",
+            kind="model",
+            priority=3,
+            weight=0.85,
+            url="https://huggingface.co",
+            tags=["model-hub"],
+        ),
+        KnowledgeSource(
+            name="GitHub",
+            kind="code",
+            priority=2,
+            weight=0.6,
+            url="https://github.com",
+            tags=["implementation"],
+        ),
+        KnowledgeSource(
+            name="Specialised Blogs",
+            kind="blog",
+            priority=1,
+            weight=0.3,
+            tags=["secondary"],
+        ),
+    ]
+)
+
+
+class SearchResult(BaseModel):
+    """Represents a single web search result."""
+
+    title: str
+    url: HttpUrl
+    snippet: Optional[str] = None
+    source: Optional[str] = None
+    score: float = 0.0
+
+    model_config = {"protected_namespaces": ()}
+
+
+class ScrapedDocument(BaseModel):
+    """Content retrieved from the web crawler or scraping layer."""
+
+    url: HttpUrl
+    source: str
+    title: Optional[str] = None
+    content: str = ""
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"protected_namespaces": ()}
+
+
+class ResearchPlanStep(BaseModel):
+    """A single step of the research plan."""
+
+    order: int
+    agent_role: str
+    description: str
+    expected_output: str
+    success_criteria: List[str] = Field(default_factory=list)
+
+    model_config = {"protected_namespaces": ()}
+
+
+class ResearchPlan(BaseModel):
+    """Structured plan produced by the ``Research Strategist``."""
+
+    goal: str
+    rationale: str
+    steps: List[ResearchPlanStep]
+
+    model_config = {"protected_namespaces": ()}
+
+
+class RerankerModelCandidate(BaseModel):
+    """Candidate reranker models identified during analysis."""
+
+    name: str
+    source: str
+    url: Optional[HttpUrl] = None
+    score: float = 0.0
+    notes: Optional[str] = None
+
+    model_config = {"protected_namespaces": ()}
+
+
+class ResearchArtifact(BaseModel):
+    """Generic artifact produced by any agent in the workflow."""
+
+    kind: str
+    title: str
+    content: str
+    source_links: List[HttpUrl] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"protected_namespaces": ()}
+
+
+class ResearchState(BaseModel):
+    """Mutable state shared between the agents."""
+
+    goal: str
+    constraints: List[str] = Field(default_factory=list)
+    prioritized_sources: PrioritizedKnowledgeSources
+    context: Dict[str, Any] = Field(default_factory=dict)
+    plan: Optional[ResearchPlan] = None
+    knowledge_base: List[ScrapedDocument] = Field(default_factory=list)
+    artifacts: List[ResearchArtifact] = Field(default_factory=list)
+    reranker_models: List[RerankerModelCandidate] = Field(default_factory=list)
+    state_log: List[str] = Field(default_factory=list)
+
+    model_config = {"protected_namespaces": ()}
+
+    def log(self, message: str) -> None:
+        """Add a timestamped message to the state log."""
+
+        timestamp = datetime.utcnow().isoformat()
+        entry = f"{timestamp} - {message}"
+        self.state_log.append(entry)
+        logger.debug(entry)
+
+
+@dataclass
+class GatheredEvidence:
+    """Container returned by the ``Data Miner`` with raw documents."""
+
+    documents: List[ScrapedDocument]
+    search_results: List[SearchResult]
+
+
+__all__ = [
+    "KnowledgeSource",
+    "PrioritizedKnowledgeSources",
+    "DEFAULT_PRIORITIZED_SOURCES",
+    "SearchResult",
+    "ScrapedDocument",
+    "ResearchPlanStep",
+    "ResearchPlan",
+    "RerankerModelCandidate",
+    "ResearchArtifact",
+    "ResearchState",
+    "GatheredEvidence",
+]

--- a/services/multi_agent/team.py
+++ b/services/multi_agent/team.py
@@ -1,0 +1,169 @@
+"""High level orchestration for the research multi-agent search workflow."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence, TypedDict
+
+try:  # pragma: no cover - optional runtime dependency
+    from langgraph.graph import END, StateGraph
+except Exception:  # pragma: no cover - executed when LangGraph is unavailable
+    END = "__end__"
+    StateGraph = None
+
+from .agents import DataAnalyst, DataMiner, ResearchStrategist, ResearchWriter
+from .integrations import (
+    Crawl4AIScraper,
+    DoclinFormatter,
+    DuckDuckGoSearchClient,
+    InMemoryGraphRAG,
+    InMemoryVectorStore,
+    SearchClient,
+)
+from .schemas import (
+    DEFAULT_PRIORITIZED_SOURCES,
+    GatheredEvidence,
+    PrioritizedKnowledgeSources,
+    ResearchArtifact,
+    ResearchState,
+)
+
+
+class MultiAgentSearchTeam:
+    """Coordinates the five research agents end-to-end."""
+
+    def __init__(
+        self,
+        *,
+        prioritized_sources: Optional[PrioritizedKnowledgeSources] = None,
+        search_client: Optional[SearchClient] = None,
+        scraper: Optional[Crawl4AIScraper] = None,
+        doc_formatter: Optional[DoclinFormatter] = None,
+        vector_store: Optional[InMemoryVectorStore] = None,
+        graph_store: Optional[InMemoryGraphRAG] = None,
+    ) -> None:
+        self.prioritized_sources = (
+            prioritized_sources
+            or DEFAULT_PRIORITIZED_SOURCES.model_copy(deep=True)
+        )
+        vector_store = vector_store or InMemoryVectorStore()
+        graph_store = graph_store or InMemoryGraphRAG()
+        search_client = search_client or DuckDuckGoSearchClient()
+        scraper = scraper or Crawl4AIScraper()
+        doc_formatter = doc_formatter or DoclinFormatter()
+
+        self.strategist = ResearchStrategist(self.prioritized_sources)
+        self.miner = DataMiner(
+            prioritized_sources=self.prioritized_sources,
+            search_client=search_client,
+            scraper=scraper,
+            vector_store=vector_store,
+            graph_store=graph_store,
+        )
+        self.analyst = DataAnalyst(
+            prioritized_sources=self.prioritized_sources,
+            doc_formatter=doc_formatter,
+            vector_store=vector_store,
+            graph_store=graph_store,
+            search_client=search_client,
+        )
+        self.writer = ResearchWriter()
+        self._state: Optional[ResearchState] = None
+        self._langgraph_app = self._build_langgraph_app()
+
+    @property
+    def state(self) -> Optional[ResearchState]:
+        """Return the most recent ``ResearchState`` after ``run`` was executed."""
+
+        return self._state
+
+    @property
+    def langgraph_app(self) -> Any:
+        """Return the compiled LangGraph app if the dependency is installed."""
+
+        return self._langgraph_app
+
+    def run(
+        self, goal: str, *, constraints: Optional[Sequence[str]] = None
+    ) -> ResearchArtifact:
+        """Execute the full multi-agent research workflow."""
+
+        if self._langgraph_app is not None:
+            initial_state: Dict[str, Any] = {
+                "goal": goal,
+                "constraints": list(constraints or []),
+            }
+            result: Dict[str, Any] = self._langgraph_app.invoke(initial_state)
+            report = result.get("report")
+            state = result.get("state")
+            if isinstance(state, ResearchState):
+                self._state = state
+            if isinstance(report, ResearchArtifact):
+                return report
+            raise RuntimeError(
+                "LangGraph execution completed without producing a research report."
+            )
+
+        state = self.strategist.define_problem(goal, constraints)
+        self.strategist.build_plan(state)
+        evidence = self.miner.gather(state)
+        analysis = self.analyst.refine(state, evidence)
+        report = self.writer.generate(state, analysis)
+        self._state = state
+        return report
+
+    # ------------------------------------------------------------------
+    # LangGraph integration helpers
+    # ------------------------------------------------------------------
+    def _build_langgraph_app(self) -> Any:
+        """Construct a LangGraph ``StateGraph`` when the dependency is available."""
+
+        if StateGraph is None:  # pragma: no cover - optional dependency path
+            return None
+
+        class GraphState(TypedDict, total=False):
+            goal: str
+            constraints: Sequence[str]
+            state: ResearchState
+            evidence: GatheredEvidence
+            analysis: ResearchArtifact
+            report: ResearchArtifact
+
+        graph = StateGraph(GraphState)
+        graph.add_node("define_problem", self._lg_define_problem)
+        graph.add_node("gather", self._lg_gather)
+        graph.add_node("analyse", self._lg_analyse)
+        graph.add_node("write", self._lg_write)
+        graph.set_entry_point("define_problem")
+        graph.add_edge("define_problem", "gather")
+        graph.add_edge("gather", "analyse")
+        graph.add_edge("analyse", "write")
+        graph.add_edge("write", END)
+        return graph.compile()
+
+    def _lg_define_problem(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        goal = payload.get("goal", "")
+        constraints = payload.get("constraints")
+        state = self.strategist.define_problem(goal, constraints)
+        self.strategist.build_plan(state)
+        return {"state": state}
+
+    def _lg_gather(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        state = payload["state"]
+        evidence = self.miner.gather(state)
+        return {"state": state, "evidence": evidence}
+
+    def _lg_analyse(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        state = payload["state"]
+        evidence = payload["evidence"]
+        analysis = self.analyst.refine(state, evidence)
+        return {"state": state, "analysis": analysis}
+
+    def _lg_write(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        state = payload["state"]
+        analysis = payload["analysis"]
+        report = self.writer.generate(state, analysis)
+        self._state = state
+        return {"state": state, "report": report}
+
+
+__all__ = ["MultiAgentSearchTeam"]


### PR DESCRIPTION
## Summary
- add a CLI entrypoint and optional LangGraph orchestration hooks for the multi-agent research team
- document the research workflow, knowledge sources, and container usage in refreshed READMEs
- supply dedicated dependency, Dockerfile, and docker-compose definitions for running the agents in isolation

## Testing
- python -m compileall services/multi_agent
- python -m services.multi_agent --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68caa40697f88332b9eab255cdd33027