### PR TITLE
Add Crawl4AI MCP server with configurable embedding schema

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements-mcp.txt ./
+RUN pip install --no-cache-dir -r requirements-mcp.txt
+
+COPY crawl4ai_mcp ./crawl4ai_mcp
+
+CMD ["python", "-m", "crawl4ai_mcp.main"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # Miau
-Miau WhisperX Service
+
+## WhisperX Service
+Legacy WhisperX-related services remain under `app.py` and the `services/` package.
+
+## Crawl4AI MCP Server
+This repository now includes a Model Context Protocol (MCP) server that crawls the web using
+[Crawl4AI](https://github.com/unclecode/crawl4ai) and stores Markdown chunks plus embeddings in PostgreSQL with `pgvector`.
+The server exposes MCP tools for crawling individual pages, crawling entire domains, querying the RAG index, listing index status,
+and purging indexed sources.
+
+### Features
+- Crawl single pages or discover entire domains via Crawl4AI's `AsyncWebCrawler` and `AsyncUrlSeeder`.
+- Chunk Markdown with heading awareness and store results in PostgreSQL using `asyncpg`.
+- Generate OpenAI embeddings (defaults to `text-embedding-3-small`) and persist them in `pgvector`.
+- Query the index via vector or hybrid (vector + FTS) strategies through an MCP tool.
+- Optional HTTP transport via FastAPI/uvicorn in addition to the stdio MCP transport.
+
+### Local Development
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-mcp.txt
+export C4MCP_DATABASE_DSN="postgresql://postgres:postgres@localhost:5432/crawl4ai_mcp"
+export OPENAI_API_KEY="sk-..."
+python -m crawl4ai_mcp.main  # stdio transport
+# or run the HTTP transport
+uvicorn crawl4ai_mcp.http_app:app --port 8051
+```
+
+### Docker Compose
+A dedicated compose file (`docker-compose.mcp.yml`) starts PostgreSQL (with pgvector), the MCP server (HTTP transport),
+and an optional Adminer instance for inspection:
+
+```bash
+docker compose -f docker-compose.mcp.yml up --build
+```
+
+This exposes:
+- MCP HTTP transport at `http://localhost:8051/mcp`
+- Adminer at `http://localhost:8080`
+
+### Running Tests
+Install development dependencies (see "Local Development" above) and run:
+
+```bash
+pytest tests -q
+```
+
+### Environment Variables
+The MCP server reads configuration via `pydantic-settings` with the `C4MCP_` prefix. Useful variables include:
+- `C4MCP_DATABASE_DSN` – PostgreSQL DSN (default: `postgresql://postgres:postgres@localhost:5432/crawl4ai_mcp`).
+- `C4MCP_EMBEDDING_MODEL` – OpenAI embedding model name (`text-embedding-3-small`).
+- `C4MCP_EMBEDDING_DIMENSIONS` – Optional embedding dimensionality override.
+- `OPENAI_API_KEY` – Required for embeddings when running outside of tests.
+

--- a/crawl4ai_mcp/__init__.py
+++ b/crawl4ai_mcp/__init__.py
@@ -1,0 +1,6 @@
+"""Crawl4AI MCP server package."""
+
+from .config import Settings, get_settings
+from .server import server
+
+__all__ = ["Settings", "get_settings", "server"]

--- a/crawl4ai_mcp/chunker.py
+++ b/crawl4ai_mcp/chunker.py
@@ -1,0 +1,99 @@
+"""Markdown chunking utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+from .models import Chunk
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$", re.MULTILINE)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Return a rough token estimate using whitespace separated words."""
+
+    text = text.strip()
+    if not text:
+        return 0
+    return max(1, len(re.findall(r"\w+|[^\w\s]", text)))
+
+
+def _split_words(text: str) -> list[str]:
+    words = text.split()
+    if not words:
+        return []
+    return words
+
+
+def _join_words(words: Sequence[str]) -> str:
+    return " ".join(words).strip()
+
+
+def chunk_markdown(
+    markdown: str,
+    *,
+    chunk_tokens: int,
+    overlap_tokens: int,
+) -> list[Chunk]:
+    """Split Markdown text into semantic-aware chunks."""
+
+    if chunk_tokens <= overlap_tokens:
+        raise ValueError("chunk_tokens must be greater than overlap_tokens")
+
+    chunks: list[Chunk] = []
+    heading_stack: list[tuple[int, str]] = []
+    last_index = 0
+    order = 0
+
+    def flush_segment(segment_text: str) -> None:
+        nonlocal order
+        content = segment_text.strip()
+        if not content:
+            return
+        words = _split_words(content)
+        start = 0
+        current_heading = heading_stack[-1][1] if heading_stack else None
+        heading_path = [heading for _, heading in heading_stack]
+        while start < len(words):
+            end = min(start + chunk_tokens, len(words))
+            chunk_words = words[start:end]
+            chunk_text = _join_words(chunk_words)
+            token_count = len(chunk_words) or _estimate_tokens(chunk_text)
+            metadata = {
+                "heading_path": heading_path,
+                "token_start": start,
+                "token_end": start + token_count,
+            }
+            chunks.append(
+                Chunk(
+                    text=chunk_text,
+                    heading=current_heading,
+                    tokens=token_count,
+                    order=order,
+                    metadata=metadata,
+                )
+            )
+            order += 1
+            if end >= len(words):
+                break
+            start = max(0, end - overlap_tokens)
+
+    for match in _HEADING_RE.finditer(markdown):
+        # Content before heading
+        if match.start() > last_index:
+            flush_segment(markdown[last_index : match.start()])
+        level = len(match.group(1))
+        heading_text = match.group(2).strip()
+        heading_stack = [entry for entry in heading_stack if entry[0] < level]
+        heading_stack.append((level, heading_text))
+        last_index = match.end()
+
+    # Tail content
+    if last_index < len(markdown):
+        flush_segment(markdown[last_index:])
+
+    return chunks
+
+
+__all__ = ["chunk_markdown"]

--- a/crawl4ai_mcp/config.py
+++ b/crawl4ai_mcp/config.py
@@ -1,0 +1,97 @@
+"""Configuration helpers for the Crawl4AI MCP server."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal, Optional
+
+from pydantic import Field, HttpUrl, PositiveInt
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the MCP server."""
+
+    model_config = SettingsConfigDict(env_prefix="C4MCP_", env_file=".env", extra="ignore")
+
+    # Database
+    database_dsn: str = Field(
+        default="postgresql://postgres:postgres@localhost:5432/crawl4ai_mcp",
+        description="Connection string for the PostgreSQL instance with pgvector.",
+    )
+    database_min_size: PositiveInt = Field(
+        default=1,
+        description="Minimum number of connections maintained by the asyncpg pool.",
+    )
+    database_max_size: PositiveInt = Field(
+        default=10,
+        description="Maximum number of connections maintained by the asyncpg pool.",
+    )
+
+    # Embeddings
+    openai_api_key: Optional[str] = Field(
+        default=None,
+        description="API key used for embedding generation. If omitted only mocks/tests will run.",
+    )
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="OpenAI embedding model identifier.",
+    )
+    embedding_dimensions: Optional[int] = Field(
+        default=1536,
+        description="Embedding dimensionality. None keeps provider defaults.",
+    )
+    embedding_batch_size: PositiveInt = Field(
+        default=64,
+        description="Maximum number of texts sent to the embedder in a single batch.",
+    )
+
+    # Crawling
+    crawl_timeout_seconds: PositiveInt = Field(default=45, description="Per-request timeout in seconds.")
+    crawl_concurrency: PositiveInt = Field(default=5, description="Max concurrent requests when crawling a domain.")
+    crawl_backoff_seconds: float = Field(
+        default=1.5,
+        description="Base backoff in seconds for retries of HTTP failures.",
+    )
+    crawl_max_retries: PositiveInt = Field(default=3, description="Maximum number of retry attempts for transient failures.")
+    crawl_user_agent: str = Field(
+        default="Crawl4AI-MCP/0.1 (+https://github.com/modelcontextprotocol)",
+        description="User agent used for crawling.",
+    )
+
+    # Chunking
+    chunk_tokens: PositiveInt = Field(default=400, description="Approximate token count per chunk.")
+    chunk_overlap_tokens: PositiveInt = Field(default=40, description="Overlap tokens between neighbouring chunks.")
+
+    # RAG
+    rag_default_strategy: Literal["vector", "hybrid", "rerank", "agentic"] = Field(
+        default="hybrid", description="Default retrieval strategy used when none supplied."
+    )
+    rag_score_threshold: float = Field(
+        default=0.25,
+        description="Minimum relevance score for returned snippets.",
+        ge=0.0,
+        le=1.0,
+    )
+    rag_max_snippets: PositiveInt = Field(default=5, description="Default number of snippets to return.")
+
+    # Optional HTTP transport
+    http_host: str = Field(default="0.0.0.0", description="Binding host for optional HTTP transport.")
+    http_port: PositiveInt = Field(default=8051, description="Binding port for optional HTTP transport.")
+    http_base_url: Optional[HttpUrl] = Field(
+        default=None,
+        description="Public base URL advertised to clients when using HTTP transport.",
+    )
+
+    # Observability
+    log_level: str = Field(default="INFO", description="Root log level.")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/crawl4ai_mcp/db.py
+++ b/crawl4ai_mcp/db.py
@@ -1,0 +1,82 @@
+"""Database helpers built on asyncpg."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+try:  # pragma: no cover - optional dependency during tests
+    import asyncpg  # type: ignore
+except ImportError:  # pragma: no cover
+    asyncpg = None  # type: ignore
+
+from .errors import RAGError
+
+
+class Database:
+    """Simple wrapper around an asyncpg pool."""
+
+    def __init__(self, dsn: str, *, min_size: int = 1, max_size: int = 10) -> None:
+        self._dsn = dsn
+        self._min_size = min_size
+        self._max_size = max_size
+        self._pool: "asyncpg.Pool" | None = None
+        self._lock = asyncio.Lock()
+
+    async def connect(self) -> None:
+        if asyncpg is None:
+            raise RAGError("asyncpg is required for database operations")
+        if self._pool is None:
+            async with self._lock:
+                if self._pool is None:
+                    self._pool = await asyncpg.create_pool(
+                        self._dsn, min_size=self._min_size, max_size=self._max_size
+                    )
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator["asyncpg.Connection"]:
+        if asyncpg is None:
+            raise RAGError("asyncpg is required for database operations")
+        if self._pool is None:
+            await self.connect()
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            yield conn
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator["asyncpg.Connection"]:
+        async with self.connection() as conn:
+            async with conn.transaction():
+                yield conn
+
+    async def execute(self, query: str, *args) -> str:
+        async with self.connection() as conn:
+            return await conn.execute(query, *args)
+
+    async def fetch(self, query: str, *args) -> list["asyncpg.Record"]:
+        async with self.connection() as conn:
+            return await conn.fetch(query, *args)
+
+    async def fetchrow(self, query: str, *args) -> "asyncpg.Record" | None:
+        async with self.connection() as conn:
+            return await conn.fetchrow(query, *args)
+
+    async def fetchval(self, query: str, *args):
+        async with self.connection() as conn:
+            return await conn.fetchval(query, *args)
+
+    async def run_migration(self, sql: str) -> None:
+        try:
+            async with self.connection() as conn:
+                await conn.execute(sql)
+        except Exception as exc:  # pragma: no cover - asyncpg already logs stack
+            raise RAGError("failed to apply migration", cause=exc) from exc
+
+
+__all__ = ["Database"]

--- a/crawl4ai_mcp/errors.py
+++ b/crawl4ai_mcp/errors.py
@@ -1,0 +1,28 @@
+"""Shared exception hierarchy for the Crawl4AI MCP server."""
+
+from __future__ import annotations
+
+
+class MCPError(Exception):
+    """Base error for MCP service related failures."""
+
+
+class CrawlError(MCPError):
+    """Raised when crawling fails."""
+
+    def __init__(self, message: str, *, url: str | None = None) -> None:
+        if url:
+            message = f"{message} (url={url})"
+        super().__init__(message)
+        self.url = url
+
+
+class RAGError(MCPError):
+    """Raised when retrieval or storage fails."""
+
+    def __init__(self, message: str, *, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+__all__ = ["MCPError", "CrawlError", "RAGError"]

--- a/crawl4ai_mcp/http_app.py
+++ b/crawl4ai_mcp/http_app.py
@@ -1,0 +1,11 @@
+"""HTTP application exposing the streamable MCP transport."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .server import server
+
+app: FastAPI = server.streamable_http_app()
+
+__all__ = ["app"]

--- a/crawl4ai_mcp/logging_config.py
+++ b/crawl4ai_mcp/logging_config.py
@@ -1,0 +1,31 @@
+"""Logging utilities for the MCP server."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable
+
+
+DEFAULT_LOG_FORMAT = (
+    "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+)
+
+
+def configure_logging(level: str = "INFO", *, extra_loggers: Iterable[str] | None = None) -> None:
+    """Configure structured-ish logging for the service."""
+
+    logging.basicConfig(level=level, format=DEFAULT_LOG_FORMAT)
+    for logger_name in extra_loggers or ():
+        logging.getLogger(logger_name).setLevel(level)
+
+
+def configure_from_env() -> None:
+    """Read log level from environment variable if present."""
+
+    level = os.getenv("C4MCP_LOG_LEVEL")
+    if level:
+        configure_logging(level)
+
+
+__all__ = ["configure_logging", "configure_from_env"]

--- a/crawl4ai_mcp/main.py
+++ b/crawl4ai_mcp/main.py
@@ -1,0 +1,13 @@
+"""Entry point for running the MCP server over stdio."""
+
+from __future__ import annotations
+
+from .server import server
+
+
+def main() -> None:
+    server.run("stdio")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/crawl4ai_mcp/migrations/schema.sql
+++ b/crawl4ai_mcp/migrations/schema.sql
@@ -1,0 +1,42 @@
+-- Enable required extensions
+create extension if not exists vector;
+create extension if not exists pg_trgm;
+create extension if not exists "uuid-ossp";
+
+-- Sources table
+create table if not exists sources (
+    id uuid primary key default uuid_generate_v4(),
+    url text not null unique,
+    title text,
+    created_at timestamptz not null default now(),
+    last_crawled_at timestamptz
+);
+
+-- Documents table
+create table if not exists documents (
+    id uuid primary key default uuid_generate_v4(),
+    source_id uuid references sources(id) on delete cascade,
+    url text not null,
+    title text,
+    md text not null,
+    meta jsonb not null default '{}',
+    content_hash text not null,
+    fetched_at timestamptz not null default now(),
+    unique (url, content_hash)
+);
+
+-- Chunks table
+create table if not exists chunks (
+    id uuid primary key default uuid_generate_v4(),
+    document_id uuid references documents(id) on delete cascade,
+    ord int not null,
+    text text not null,
+    heading text,
+    tokens int not null,
+    embedding vector(1536),
+    meta jsonb not null default '{}'
+);
+
+create index if not exists idx_chunks_doc_ord on chunks(document_id, ord);
+create index if not exists idx_chunks_hnsw on chunks using hnsw (embedding vector_cosine_ops);
+create index if not exists chunks_fts_idx on chunks using gin (to_tsvector('english', text));

--- a/crawl4ai_mcp/models.py
+++ b/crawl4ai_mcp/models.py
@@ -1,0 +1,84 @@
+"""Pydantic models shared across the server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, List, Sequence
+
+from pydantic import BaseModel, Field
+
+
+@dataclass(slots=True)
+class Chunk:
+    """Representation of a document chunk before persistence."""
+
+    text: str
+    heading: str | None
+    tokens: int
+    order: int
+    metadata: dict[str, Any]
+
+
+@dataclass(slots=True)
+class CrawlDocument:
+    """Holds the Markdown document returned from the crawler."""
+
+    url: str
+    title: str | None
+    markdown: str
+    metadata: dict[str, Any]
+    chunks: Sequence[Chunk]
+
+
+class RAGHit(BaseModel):
+    """Result item returned from a retrieval query."""
+
+    chunk_id: str = Field(..., description="UUID of the chunk")
+    score: float = Field(..., ge=0.0, le=1.0)
+    snippet: str = Field(..., description="Markdown snippet")
+    url: str = Field(..., description="Origin document URL")
+    document_id: str = Field(..., description="UUID of the source document")
+    heading: str | None = Field(None, description="Heading associated with the snippet")
+
+
+class IndexStatus(BaseModel):
+    """Simple status summary for the index."""
+
+    sources: int
+    documents: int
+    chunks: int
+    last_ingest_at: datetime | None = None
+
+
+class CrawlResponse(BaseModel):
+    status: str
+    source_id: str | None = None
+    document_ids: List[str] = Field(default_factory=list)
+    chunks_indexed: int = 0
+    message: str | None = None
+
+
+class QueryResponse(BaseModel):
+    status: str
+    hits: List[RAGHit] = Field(default_factory=list)
+    message: str | None = None
+
+
+class PurgeResponse(BaseModel):
+    status: str
+    deleted_sources: int
+    deleted_documents: int
+    deleted_chunks: int
+    message: str | None = None
+
+
+__all__ = [
+    "Chunk",
+    "CrawlDocument",
+    "RAGHit",
+    "IndexStatus",
+    "CrawlResponse",
+    "QueryResponse",
+    "PurgeResponse",
+]

--- a/crawl4ai_mcp/server.py
+++ b/crawl4ai_mcp/server.py
@@ -1,0 +1,155 @@
+"""Model Context Protocol server wiring."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Iterable
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from .config import get_settings
+from .db import Database
+from .errors import CrawlError, RAGError
+from .logging_config import configure_logging
+from .models import CrawlResponse, PurgeResponse, QueryResponse
+from .services.crawler import crawl_domain as crawl_domain_service
+from .services.crawler import crawl_single_page as crawl_single_page_service
+from .services.embedding import EmbeddingClient
+from .services.rag_engine import IngestStats, RAGEngine
+
+LOGGER = logging.getLogger("crawl4ai_mcp.server")
+
+settings = get_settings()
+configure_logging(settings.log_level)
+
+database = Database(
+    settings.database_dsn,
+    min_size=settings.database_min_size,
+    max_size=settings.database_max_size,
+)
+embedder = EmbeddingClient(
+    api_key=settings.openai_api_key,
+    model=settings.embedding_model,
+    dimensions=settings.embedding_dimensions,
+    batch_size=settings.embedding_batch_size,
+)
+rag_engine = RAGEngine(database, embedder, settings)
+
+
+@asynccontextmanager
+async def lifespan(app: FastMCP):
+    await database.connect()
+    try:
+        await rag_engine.ensure_schema()
+        yield
+    finally:
+        await database.close()
+
+
+server = FastMCP(
+    name="crawl4ai-mcp",
+    instructions="Crawl websites with Crawl4AI and query a pgvector RAG index.",
+    lifespan=lifespan,
+)
+
+
+async def _ingest_documents(source_url: str, documents: Iterable) -> IngestStats:
+    await rag_engine.ensure_schema()
+    return await rag_engine.ingest(source_url, list(documents))
+
+
+@server.tool()
+async def crawl_single_page(url: str, *, context: Context | None = None) -> Dict[str, Any]:
+    """Crawl a single URL and index its content."""
+
+    try:
+        document = await crawl_single_page_service(url, settings)
+        stats = await _ingest_documents(url, [document])
+        response = CrawlResponse(
+            status="ok",
+            source_id=stats.source_id,
+            document_ids=stats.document_ids,
+            chunks_indexed=stats.chunks_indexed,
+        )
+        return response.model_dump()
+    except CrawlError as exc:
+        LOGGER.exception("crawl failed for %s", url)
+        return CrawlResponse(status="error", message=str(exc)).model_dump()
+    except RAGError as exc:
+        LOGGER.exception("ingest failed for %s", url)
+        return CrawlResponse(status="error", message=str(exc)).model_dump()
+
+
+@server.tool()
+async def crawl_domain(
+    seed_url: str,
+    max_pages: int = 20,
+    sitemap: bool = True,
+    *,
+    context: Context | None = None,
+) -> Dict[str, Any]:
+    """Crawl multiple pages from a domain."""
+
+    try:
+        documents = await crawl_domain_service(
+            seed_url,
+            max_pages=max_pages,
+            settings=settings,
+            sitemap=sitemap,
+        )
+        stats = await _ingest_documents(seed_url, documents)
+        return CrawlResponse(
+            status="ok",
+            source_id=stats.source_id,
+            document_ids=stats.document_ids,
+            chunks_indexed=stats.chunks_indexed,
+        ).model_dump()
+    except CrawlError as exc:
+        LOGGER.exception("domain crawl failed for %s", seed_url)
+        return CrawlResponse(status="error", message=str(exc)).model_dump()
+    except RAGError as exc:
+        LOGGER.exception("domain ingest failed for %s", seed_url)
+        return CrawlResponse(status="error", message=str(exc)).model_dump()
+
+
+@server.tool()
+async def query_rag(
+    query: str,
+    k: int = 5,
+    strategy: str | None = None,
+    *,
+    context: Context | None = None,
+) -> Dict[str, Any]:
+    """Query the RAG index."""
+
+    try:
+        hits = await rag_engine.query(query, k=k, strategy=strategy)
+        return QueryResponse(status="ok", hits=hits).model_dump()
+    except RAGError as exc:
+        LOGGER.exception("rag query failed")
+        return QueryResponse(status="error", message=str(exc)).model_dump()
+
+
+@server.tool()
+async def index_status(*, context: Context | None = None) -> Dict[str, Any]:
+    """Return index statistics."""
+
+    status = await rag_engine.index_status()
+    return {"status": "ok", "index": status.model_dump()}
+
+
+@server.tool()
+async def purge_source(identifier: str, *, context: Context | None = None) -> Dict[str, Any]:
+    """Remove a source (by UUID or URL) from the index."""
+
+    deleted_sources, deleted_docs, deleted_chunks = await rag_engine.purge_source(identifier)
+    return PurgeResponse(
+        status="ok",
+        deleted_sources=deleted_sources,
+        deleted_documents=deleted_docs,
+        deleted_chunks=deleted_chunks,
+    ).model_dump()
+
+
+__all__ = ["server"]

--- a/crawl4ai_mcp/services/crawler.py
+++ b/crawl4ai_mcp/services/crawler.py
@@ -1,0 +1,185 @@
+"""Crawl4AI powered crawling utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Awaitable, Callable, TypeVar
+from urllib.parse import urlparse
+
+try:  # pragma: no cover - optional dependency at runtime
+    from crawl4ai import (
+        AsyncUrlSeeder,
+        AsyncWebCrawler,
+        CacheMode,
+        CrawlerRunConfig,
+        SeedingConfig,
+    )
+except Exception:  # pragma: no cover - tests may not install crawl4ai
+    AsyncUrlSeeder = None  # type: ignore
+    AsyncWebCrawler = None  # type: ignore
+    CacheMode = None  # type: ignore
+    CrawlerRunConfig = None  # type: ignore
+    SeedingConfig = None  # type: ignore
+
+from ..chunker import chunk_markdown
+from ..config import Settings
+from ..errors import CrawlError
+from ..models import CrawlDocument
+
+LOGGER = logging.getLogger("crawl4ai_mcp.crawler")
+
+
+T = TypeVar("T")
+
+
+async def _retry(coro_factory: Callable[[], Awaitable[T]], *, retries: int, base_delay: float) -> T:
+    last_error: Exception | None = None
+    for attempt in range(retries):
+        try:
+            return await coro_factory()
+        except Exception as exc:  # pragma: no cover - re-raised with context
+            last_error = exc
+            delay = base_delay * (2**attempt)
+            jitter = random.uniform(0.1, 0.5)
+            await asyncio.sleep(delay + jitter)
+    assert last_error is not None
+    raise last_error
+
+
+async def _run_single_crawl(
+    crawler: "AsyncWebCrawler",
+    url: str,
+    settings: Settings,
+) -> CrawlDocument:
+    async def run_once():
+        config = CrawlerRunConfig(
+            cache_mode=CacheMode.BYPASS if CacheMode else None,
+            user_agent=settings.crawl_user_agent,
+            verbose=False,
+        )
+        result = await crawler.arun(url=url, config=config)
+        if not getattr(result, "success", False):
+            error_message = getattr(result, "error_message", "crawl failed")
+            raise CrawlError(error_message or "crawl failed", url=url)
+        markdown_obj = getattr(result, "markdown", None)
+        if markdown_obj is None:
+            raise CrawlError("crawler returned no markdown", url=url)
+        if hasattr(markdown_obj, "raw_markdown"):
+            markdown = markdown_obj.raw_markdown
+        else:
+            markdown = str(markdown_obj)
+        raw_meta = getattr(result, "metadata", {}) or {}
+        metadata = {
+            "url": url,
+            "links": getattr(result, "links", {}),
+            "media": getattr(result, "media", {}),
+            "metadata": raw_meta,
+            "status_code": getattr(result, "status_code", None),
+            "discovered_at": asyncio.get_event_loop().time(),
+        }
+        chunks = chunk_markdown(
+            markdown,
+            chunk_tokens=settings.chunk_tokens,
+            overlap_tokens=settings.chunk_overlap_tokens,
+        )
+        title = raw_meta.get("title") if isinstance(raw_meta, dict) else None
+        return CrawlDocument(
+            url=url,
+            title=title,
+            markdown=markdown,
+            metadata=metadata,
+            chunks=chunks,
+        )
+
+    return await _retry(
+        run_once,
+        retries=settings.crawl_max_retries,
+        base_delay=settings.crawl_backoff_seconds,
+    )
+
+
+async def crawl_single_page(url: str, settings: Settings) -> CrawlDocument:
+    if AsyncWebCrawler is None or CrawlerRunConfig is None:
+        raise CrawlError("crawl4ai is not installed", url=url)
+
+    async with AsyncWebCrawler() as crawler:  # type: ignore[arg-type]
+        return await _run_single_crawl(crawler, url, settings)
+
+
+async def _discover_domain_urls(seed_url: str, settings: Settings, max_pages: int, sitemap: bool) -> list[str]:
+    if AsyncUrlSeeder is None or SeedingConfig is None:
+        raise CrawlError("crawl4ai seeding utilities not available", url=seed_url)
+
+    parsed = urlparse(seed_url)
+    if not parsed.netloc:
+        raise CrawlError("seed URL must include a host", url=seed_url)
+    domain = parsed.netloc
+    scheme = parsed.scheme or "https"
+
+    async with AsyncUrlSeeder() as seeder:  # type: ignore[arg-type]
+        config = SeedingConfig(
+            source="sitemap" if sitemap else "cc",
+            pattern=f"*{domain}*",
+            max_urls=max_pages,
+            hits_per_sec=settings.crawl_concurrency,
+            live_check=False,
+            extract_head=True,
+        )
+        results = await seeder.urls(domain, config)  # type: ignore[arg-type]
+        urls = []
+        for item in results:
+            candidate = item.get("url")
+            if not candidate:
+                continue
+            if candidate.startswith("//"):
+                candidate = f"{scheme}:{candidate}"
+            if candidate.startswith("/"):
+                candidate = f"{scheme}://{domain}{candidate}"
+            if urlparse(candidate).netloc.endswith(domain):
+                urls.append(candidate)
+        unique_urls: list[str] = []
+        seen = set()
+        for item in urls:
+            if item not in seen:
+                seen.add(item)
+                unique_urls.append(item)
+        return unique_urls[:max_pages]
+
+
+async def crawl_domain(
+    seed_url: str,
+    *,
+    max_pages: int,
+    settings: Settings,
+    sitemap: bool = True,
+) -> list[CrawlDocument]:
+    if AsyncWebCrawler is None:
+        raise CrawlError("crawl4ai is not installed", url=seed_url)
+
+    urls = await _discover_domain_urls(seed_url, settings, max_pages, sitemap)
+    if not urls:
+        raise CrawlError("no URLs discovered for domain", url=seed_url)
+
+    async with AsyncWebCrawler() as crawler:  # type: ignore[arg-type]
+        semaphore = asyncio.Semaphore(settings.crawl_concurrency)
+
+        async def sem_task(target_url: str) -> CrawlDocument:
+            async with semaphore:
+                return await _run_single_crawl(crawler, target_url, settings)
+
+        tasks = [
+            sem_task(url)
+            for url in urls
+        ]
+        documents: list[CrawlDocument] = []
+        for future in asyncio.as_completed(tasks):
+            try:
+                documents.append(await future)
+            except CrawlError as exc:
+                LOGGER.warning("failed to crawl %s: %s", exc.url, exc)
+        return documents
+
+
+__all__ = ["crawl_single_page", "crawl_domain"]

--- a/crawl4ai_mcp/services/embedding.py
+++ b/crawl4ai_mcp/services/embedding.py
@@ -1,0 +1,60 @@
+"""Embedding helpers using OpenAI's API."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+try:  # pragma: no cover - optional import
+    from openai import AsyncOpenAI  # type: ignore
+except Exception:  # pragma: no cover - fallback during tests without dependency
+    AsyncOpenAI = None  # type: ignore
+
+from ..errors import RAGError
+
+
+class EmbeddingClient:
+    """Wrapper for generating embeddings."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        model: str,
+        dimensions: int | None,
+        batch_size: int = 64,
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._dimensions = dimensions
+        self._batch_size = batch_size
+        self._client = AsyncOpenAI(api_key=api_key) if AsyncOpenAI and api_key else None
+
+    @property
+    def is_configured(self) -> bool:
+        return self._client is not None
+
+    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        if self._client is None:
+            raise RAGError("embedding client is not configured (missing API key)")
+
+        all_embeddings: list[list[float]] = []
+        for start in range(0, len(texts), self._batch_size):
+            batch = texts[start : start + self._batch_size]
+            response = await self._client.embeddings.create(
+                input=batch,
+                model=self._model,
+                dimensions=self._dimensions,
+            )
+            # Response order preserved
+            for item in response.data:
+                all_embeddings.append(list(item.embedding))
+        return all_embeddings
+
+    async def embed_query(self, text: str) -> list[float]:
+        embeddings = await self.embed_texts([text])
+        return embeddings[0] if embeddings else []
+
+
+__all__ = ["EmbeddingClient"]

--- a/crawl4ai_mcp/services/rag_engine.py
+++ b/crawl4ai_mcp/services/rag_engine.py
@@ -1,0 +1,307 @@
+"""pgvector-powered retrieval engine."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+from uuid import UUID
+
+from ..config import Settings
+from ..db import Database
+from ..errors import RAGError
+from ..models import Chunk, CrawlDocument, IndexStatus, RAGHit
+from .embedding import EmbeddingClient
+
+LOGGER = logging.getLogger("crawl4ai_mcp.rag")
+
+_VECTOR_SQL = """
+select
+    c.id as chunk_id,
+    1 - (c.embedding <=> $1) as score,
+    c.text,
+    c.heading,
+    d.url,
+    d.id as document_id
+from chunks c
+join documents d on d.id = c.document_id
+where c.embedding is not null
+order by c.embedding <=> $1 asc
+limit $2
+"""
+
+_HYBRID_SQL = """
+with ranked as (
+    select
+        c.id as chunk_id,
+        1 - (c.embedding <=> $1) as vector_score,
+        ts_rank_cd(to_tsvector('english', c.text), plainto_tsquery($2)) as text_score,
+        c.text,
+        c.heading,
+        d.url,
+        d.id as document_id
+    from chunks c
+    join documents d on d.id = c.document_id
+    where c.embedding is not null
+)
+select chunk_id,
+       (0.65 * vector_score) + (0.35 * coalesce(text_score, 0)) as score,
+       text,
+       heading,
+       url,
+       document_id
+from ranked
+order by score desc
+limit $3
+"""
+
+
+@dataclass(slots=True)
+class IngestStats:
+    source_id: str
+    document_ids: list[str]
+    chunks_indexed: int
+
+
+class RAGEngine:
+    """Handles ingestion and retrieval."""
+
+    _DEFAULT_VECTOR_DIMENSION = 1536
+
+    def __init__(
+        self,
+        database: Database,
+        embedder: EmbeddingClient,
+        settings: Settings,
+    ) -> None:
+        self._db = database
+        self._embedder = embedder
+        self._settings = settings
+        self._schema_lock = asyncio.Lock()
+        self._schema_ready = False
+        self._schema_path = (
+            Path(__file__).resolve().parent.parent / "migrations" / "schema.sql"
+        )
+
+    async def ensure_schema(self) -> None:
+        async with self._schema_lock:
+            if self._schema_ready:
+                return
+            sql = self._render_schema_sql()
+            await self._db.run_migration(sql)
+            target_dim = self._settings.embedding_dimensions or self._DEFAULT_VECTOR_DIMENSION
+            await self._ensure_vector_dimension(target_dim)
+            self._schema_ready = True
+
+    def _render_schema_sql(self) -> str:
+        sql = self._schema_path.read_text()
+        target_dim = self._settings.embedding_dimensions
+        if target_dim and target_dim != self._DEFAULT_VECTOR_DIMENSION:
+            sql = sql.replace("vector(1536)", f"vector({target_dim})")
+        return sql
+
+    async def _ensure_vector_dimension(self, target_dim: int) -> None:
+        if target_dim <= 0:
+            raise RAGError("embedding dimension must be positive")
+
+        async with self._db.transaction() as conn:
+            row = await conn.fetchrow(
+                """
+                select format_type(att.atttypid, att.atttypmod) as type
+                from pg_attribute att
+                where att.attrelid = (
+                    select oid
+                    from pg_class
+                    where relname = 'chunks'
+                      and relnamespace = 'public'::regnamespace
+                )
+                  and att.attname = 'embedding'
+            """
+            )
+            if not row:
+                return
+
+            current_dim = self._extract_vector_dimension(row.get("type"))
+            if current_dim is None:
+                return
+            if current_dim == target_dim:
+                return
+
+            LOGGER.info(
+                "updating embedding vector dimension from %s to %s", current_dim, target_dim
+            )
+            await conn.execute("drop index if exists idx_chunks_hnsw")
+            await conn.execute(
+                f"alter table chunks alter column embedding type vector({target_dim})"
+            )
+            await conn.execute(
+                "create index if not exists idx_chunks_hnsw on chunks using hnsw (embedding vector_cosine_ops)"
+            )
+
+    @staticmethod
+    def _extract_vector_dimension(type_definition: str | None) -> int | None:
+        if not type_definition:
+            return None
+        match = re.search(r"vector\((\d+)\)", type_definition)
+        if not match:
+            return None
+        return int(match.group(1))
+
+    async def ingest(self, source_url: str, documents: Sequence[CrawlDocument]) -> IngestStats:
+        if not documents:
+            raise RAGError("no documents provided for ingestion")
+        if not self._embedder.is_configured:
+            raise RAGError("embedder is not configured")
+
+        # Pre-compute embeddings to keep DB transactions short
+        chunk_payloads: list[list[tuple[Chunk, list[float]]]] = []
+        for document in documents:
+            valid_chunks = [chunk for chunk in document.chunks if chunk.text]
+            texts = [chunk.text for chunk in valid_chunks]
+            embeddings = await self._embedder.embed_texts(texts) if texts else []
+            if len(embeddings) != len(valid_chunks):
+                raise RAGError("embedding count mismatch for document")
+            chunk_payloads.append(list(zip(valid_chunks, embeddings)))
+
+        async with self._db.transaction() as conn:
+            source_row = await conn.fetchrow(
+                """
+                insert into sources (url, title, last_crawled_at)
+                values ($1, $2, now())
+                on conflict (url) do update set title = excluded.title, last_crawled_at = now()
+                returning id
+                """,
+                source_url,
+                documents[0].title,
+            )
+            if not source_row:
+                raise RAGError("failed to upsert source")
+            source_id = str(source_row["id"])
+
+            document_ids: list[str] = []
+            chunk_total = 0
+
+            for document, chunk_embeddings in zip(documents, chunk_payloads):
+                content_hash = hashlib.sha256(document.markdown.encode("utf-8")).hexdigest()
+                doc_row = await conn.fetchrow(
+                    """
+                    insert into documents (source_id, url, title, md, meta, content_hash)
+                    values ($1, $2, $3, $4, $5::jsonb, $6)
+                    on conflict (url, content_hash) do nothing
+                    returning id
+                    """,
+                    source_row["id"],
+                    document.url,
+                    document.title,
+                    document.markdown,
+                    json.dumps(document.metadata),
+                    content_hash,
+                )
+                if doc_row is None:
+                    LOGGER.info("document unchanged, skipping %s", document.url)
+                    continue
+                document_id = doc_row["id"]
+                document_ids.append(str(document_id))
+                await conn.execute("delete from chunks where document_id = $1", document_id)
+                for chunk, embedding in chunk_embeddings:
+                    await conn.execute(
+                        """
+                        insert into chunks (document_id, ord, text, heading, tokens, embedding, meta)
+                        values ($1, $2, $3, $4, $5, $6, $7::jsonb)
+                        """,
+                        document_id,
+                        chunk.order,
+                        chunk.text,
+                        chunk.heading,
+                        chunk.tokens,
+                        embedding,
+                        json.dumps(chunk.metadata),
+                    )
+                    chunk_total += 1
+
+            return IngestStats(source_id=source_id, document_ids=document_ids, chunks_indexed=chunk_total)
+
+    async def query(self, query: str, *, k: int | None = None, strategy: str | None = None) -> list[RAGHit]:
+        if not query:
+            raise RAGError("query must not be empty")
+        if not self._embedder.is_configured:
+            raise RAGError("embedder is not configured")
+
+        strategy = strategy or self._settings.rag_default_strategy
+        strategy = strategy.lower()
+        if strategy not in {"vector", "hybrid", "rerank", "agentic"}:
+            raise RAGError(f"unknown strategy: {strategy}")
+        limit = k or self._settings.rag_max_snippets
+        query_vector = await self._embedder.embed_query(query)
+
+        if strategy == "vector":
+            rows = await self._db.fetch(_VECTOR_SQL, query_vector, limit)
+        else:
+            # Treat rerank/agentic as hybrid baseline for now
+            rows = await self._db.fetch(_HYBRID_SQL, query_vector, query, limit)
+
+        hits: list[RAGHit] = []
+        for row in rows:
+            score = float(row["score"])
+            if score < self._settings.rag_score_threshold:
+                continue
+            hits.append(
+                RAGHit(
+                    chunk_id=str(row["chunk_id"]),
+                    score=score,
+                    snippet=row["text"],
+                    url=row["url"],
+                    document_id=str(row["document_id"]),
+                    heading=row.get("heading"),
+                )
+            )
+        return hits[:limit]
+
+    async def purge_source(self, identifier: str) -> tuple[int, int, int]:
+        async with self._db.transaction() as conn:
+            if self._is_uuid(identifier):
+                source_row = await conn.fetchrow("select id from sources where id = $1", UUID(identifier))
+            else:
+                source_row = await conn.fetchrow("select id from sources where url = $1", identifier)
+            if not source_row:
+                return (0, 0, 0)
+            source_id = source_row["id"]
+            doc_rows = await conn.fetch("select id from documents where source_id = $1", source_id)
+            doc_ids = [row["id"] for row in doc_rows]
+            chunk_count = 0
+            if doc_ids:
+                chunk_count = await conn.fetchval(
+                    "select count(*) from chunks where document_id = any($1::uuid[])",
+                    doc_ids,
+                )
+            deleted_docs = len(doc_ids)
+            await conn.execute("delete from sources where id = $1", source_id)
+            return (1, deleted_docs, chunk_count)
+
+    async def index_status(self) -> IndexStatus:
+        row_sources = await self._db.fetchrow("select count(*) as count from sources")
+        row_documents = await self._db.fetchrow("select count(*) as count from documents")
+        row_chunks = await self._db.fetchrow("select count(*) as count from chunks")
+        last_ingest = await self._db.fetchrow("select max(fetched_at) as ts from documents")
+        return IndexStatus(
+            sources=int(row_sources["count"]) if row_sources else 0,
+            documents=int(row_documents["count"]) if row_documents else 0,
+            chunks=int(row_chunks["count"]) if row_chunks else 0,
+            last_ingest_at=last_ingest["ts"] if last_ingest and last_ingest["ts"] else None,
+        )
+
+    @staticmethod
+    def _is_uuid(value: str) -> bool:
+        try:
+            UUID(value)
+            return True
+        except Exception:
+            return False
+
+
+__all__ = ["RAGEngine", "IngestStats"]

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: mcp
+      POSTGRES_PASSWORD: mcp
+      POSTGRES_DB: crawl4ai_mcp
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mcp"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.mcp
+    environment:
+      C4MCP_DATABASE_DSN: postgresql://mcp:mcp@db:5432/crawl4ai_mcp
+      C4MCP_LOG_LEVEL: INFO
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8051:8051"
+    command: uvicorn crawl4ai_mcp.http_app:app --host 0.0.0.0 --port 8051
+
+  adminer:
+    image: adminer:4.8.1
+    restart: unless-stopped
+    environment:
+      ADMINER_DEFAULT_SERVER: db
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,0 +1,8 @@
+asyncpg>=0.29
+crawl4ai>=0.7.4
+mcp>=1.14.0
+openai>=1.0.0
+fastapi>=0.111.0
+uvicorn>=0.35.0
+python-dotenv>=1.0.0
+structlog>=23.2.0

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,26 @@
+from crawl4ai_mcp.chunker import chunk_markdown
+
+
+def test_chunker_splits_on_headings():
+    markdown = """# Title
+
+Paragraph one has some text.
+
+## Section
+More text here spanning multiple sentences.
+"""
+    chunks = chunk_markdown(markdown, chunk_tokens=10, overlap_tokens=2)
+    assert len(chunks) >= 2
+    assert chunks[0].heading == "Title"
+    assert chunks[0].metadata["heading_path"] == ["Title"]
+    assert all(chunk.text for chunk in chunks)
+
+
+def test_chunker_requires_larger_chunk_than_overlap():
+    markdown = "# Heading\nContent"
+    try:
+        chunk_markdown(markdown, chunk_tokens=5, overlap_tokens=5)
+    except ValueError as exc:
+        assert "chunk_tokens" in str(exc)
+    else:  # pragma: no cover - ensure failure visible
+        assert False

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,0 +1,12 @@
+import pytest
+
+from crawl4ai_mcp.errors import RAGError
+from crawl4ai_mcp.services.embedding import EmbeddingClient
+
+
+@pytest.mark.asyncio
+async def test_embedding_client_requires_api_key():
+    client = EmbeddingClient(api_key=None, model="text-embedding-3-small", dimensions=1536)
+    assert client.is_configured is False
+    with pytest.raises(RAGError):
+        await client.embed_texts(["hello"])

--- a/tests/test_rag_engine_utils.py
+++ b/tests/test_rag_engine_utils.py
@@ -1,0 +1,24 @@
+from crawl4ai_mcp.config import Settings
+from crawl4ai_mcp.services.rag_engine import RAGEngine
+
+
+def test_is_uuid_helper():
+    assert RAGEngine._is_uuid("12345678-1234-1234-1234-1234567890ab")
+    assert not RAGEngine._is_uuid("not-a-uuid")
+
+
+def test_extract_vector_dimension():
+    assert RAGEngine._extract_vector_dimension("vector(2048)") == 2048
+    assert RAGEngine._extract_vector_dimension("vector(1536)") == 1536
+    assert RAGEngine._extract_vector_dimension("text") is None
+    assert RAGEngine._extract_vector_dimension(None) is None
+
+
+def test_render_schema_replaces_dimension(tmp_path):
+    settings = Settings(embedding_dimensions=1024)
+    engine = RAGEngine(database=object(), embedder=object(), settings=settings)
+    schema_file = tmp_path / "schema.sql"
+    schema_file.write_text("create table foo (embedding vector(1536));")
+    engine._schema_path = schema_file  # type: ignore[attr-defined]
+    sql = engine._render_schema_sql()
+    assert "vector(1024)" in sql

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,8 @@
+from crawl4ai_mcp.config import Settings
+
+
+def test_settings_defaults_are_defined():
+    settings = Settings()
+    assert settings.database_dsn.startswith("postgresql://")
+    assert settings.embedding_model == "text-embedding-3-small"
+    assert settings.chunk_tokens > settings.chunk_overlap_tokens


### PR DESCRIPTION
## Summary
- add a crawl4ai_mcp package that wires Crawl4AI crawling, OpenAI embeddings, and a pgvector-backed RAG engine exposed over MCP stdio/HTTP tools
- provide Docker and requirements files plus README instructions for running the new MCP server stack
- cover chunking, embedding client, settings defaults, and rag engine helpers with pytest-based unit tests

## Testing
- PYTHONPATH=. pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cbd63f81f4833285052ea74f686981